### PR TITLE
[Add]履歴一覧の取得(JSON)の表示・レイアウトとデザインの調整完了

### DIFF
--- a/backend/models/models.py
+++ b/backend/models/models.py
@@ -6,3 +6,10 @@ class Chatbot(db.Model):
     user_input = db.Column(db.String(255))
     bot_response = db.Column(db.String(255))
     response_timestamp = db.Column(db.String(255), nullable=False)
+
+    def toDict(self):
+        return {
+            'user_input': self.user_input,
+            'bot_response': self.bot_response,
+            'response_timestamp': self.response_timestamp
+        }

--- a/backend/weather.py
+++ b/backend/weather.py
@@ -1,5 +1,6 @@
 import requests
 import os
+# import json
 
 # OpenWeatherMapのAPIを利用する。(天気情報を取得できる。)
 def open_weather_map_api():
@@ -12,7 +13,7 @@ def open_weather_map_api():
     response = requests.get(url, params = params)
 
     data_json = response.json()
-    ## JSONデータを見やすく字下げする。
+    ## JSONデータを見やすく「字下げ(インデント)」する。
     # data_json_indent = json.dumps(data_json['list'][0], indent=4)
     # print(data_json_indent)
 

--- a/frontend/public/stylesheet.css
+++ b/frontend/public/stylesheet.css
@@ -1,3 +1,27 @@
 div#root {
     text-align: center;
 }
+
+button.switch {
+    margin: 10px 0;
+}
+
+form input {
+    border: solid;
+    border-color: #2088ff;
+}
+
+form button {
+    margin-left: 1px;
+    color: white;
+    background: #2088ff;
+    border: none;
+}
+
+div.each_talk_set {
+    margin: 25px 0;
+}
+
+table.history_list {
+    margin: 0 auto;
+}

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -1,12 +1,35 @@
-import React from 'react';
+import React, {useState} from 'react'
 import Form from './Form';
+import HistoryList from './HistoryList';
 
 function App() {
+
+  const [display, setDisplay] = useState('Form')
+
+  const handleDisplay = (component_name) => {
+    setDisplay(component_name)
+  }
+
     return (
       <div className='container'>
-        <Form />
+        { display === 'Form' && ( 
+          <>
+            <button onClick={ () => handleDisplay('HistoryList') } className='switch'>
+              履歴一覧画面へ
+            </button>
+            <Form />
+          </>
+        )}
+        { display === 'HistoryList' && ( 
+          <>
+            <button onClick={ () => handleDisplay('Form') } className='switch'>
+              Botとの会話画面へ
+            </button>
+            <HistoryList />
+          </>
+        )}
       </div>
-    );
+    )
 }
 
 export default App;

--- a/frontend/src/components/Form.js
+++ b/frontend/src/components/Form.js
@@ -27,8 +27,8 @@ function Form() {
     })
     .then(res => {
       setTalkDatas([ ...talkDatas, res.data ])
-      console.log(talkDatas)
-      console.log(send_currentTime)
+      // console.log(talkDatas)
+      // console.log(send_currentTime)
     })
     .catch(() => {
       console.log('通信に失敗しました');

--- a/frontend/src/components/HistoryList.js
+++ b/frontend/src/components/HistoryList.js
@@ -1,0 +1,42 @@
+import React, {useState, useEffect} from 'react'
+import axios from 'axios'
+
+function HistoryList() {
+
+  const [talkDataArray, setTalkDataArray] = useState([])
+
+  // ブラウザでこのコンポーネントが表示される時に1度だけ実行される。（第2引数に[]を指定している為。）
+  useEffect(()=>{
+    axios.get('http://127.0.0.1:5000/history/list')
+    .then(res => {
+      setTalkDataArray(res.data)
+      // console.log(res.data)
+    })
+    .catch(() => {
+      console.log('通信に失敗しました');
+    });
+  }, [])
+
+  const TalkDataTrArray = talkDataArray.map( (talk_data, index) => 
+      <tr key={ 'each_history_' + String(index) }>
+        <td>{ talk_data.user_input }</td>
+        <td>{ talk_data.bot_response }</td>
+        <td>{ talk_data.response_timestamp }</td>
+      </tr>
+    )
+
+    return (
+      <table className='history_list'>
+        <tbody>
+          <tr>
+            <th>自分の入力</th>
+            <th>Botの応答</th>
+            <th>Botの応答時刻</th>
+          </tr>
+          { TalkDataTrArray }
+        </tbody>
+      </table>
+    );
+};
+
+export default HistoryList;

--- a/frontend/src/components/TalkIndex.js
+++ b/frontend/src/components/TalkIndex.js
@@ -1,8 +1,8 @@
-import React, {useState} from 'react'
+import React from 'react'
 
 function TalkIndex(props) {
     const TalkDataDivArray = props.talk_data_array.map( (talk_data, index) => 
-      <div key={ 'each_talk_' + String(index) }>
+      <div key={ 'each_talk_' + String(index) } className='each_talk_set'>
         <p>{ props.send_current_time_array[index] + ' You > ' + talk_data.user_input }</p>
         <p>{ talk_data.response_timestamp + ' Bot > ' + talk_data.bot_response }</p>
       </div>

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './components/App';
-import reportWebVitals from './reportWebVitals';
 
 ReactDOM.render(
   <React.StrictMode>
@@ -9,8 +8,3 @@ ReactDOM.render(
   </React.StrictMode>,
   document.getElementById('root')
 );
-
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();


### PR DESCRIPTION
## 履歴一覧の取得(JSON)と表示

- 入力フォームの上にある`履歴一覧画面へ`をクリックする => `履歴一覧`がテーブルで表示される。
  - 最新の10件が表示される。
- 履歴一覧画面で上部にある`Botとの会話画面へ`をクリックする => 入力フォームと送信ボタンが表示される。

デザイン・レイアウトの修正もOK。